### PR TITLE
Chore edit redflag comment 163441036

### DIFF
--- a/api/models/database/incidentdb_api.py
+++ b/api/models/database/incidentdb_api.py
@@ -34,7 +34,6 @@ def create_incident(**incident):
         ))
         incident_id = cur.fetchone()
         conn.commit()
-        cur.close()
         return incident_id
     except Exception as error:
         return error
@@ -57,7 +56,6 @@ def get_all_redflag_incidents():
         cur = conn.up()
         cur.execute(sql)
         rows = cur.fetchall()
-        cur.close()
         return rows
     except Exception as error:
         return error
@@ -78,7 +76,6 @@ def get_incident_by_id(incident_id):
         cur = conn.up()
         cur.execute(sql)
         row = cur.fetchone()
-        cur.close()
         return row
     except Exception as error:
         return error
@@ -101,7 +98,6 @@ def get_all_intervention_incidents():
         cur = conn.up()
         cur.execute(sql)
         rows = cur.fetchall()
-        cur.close()
         return rows
     except Exception as error:
         return error
@@ -123,7 +119,29 @@ def update_location(incident_id, location=None):
         cur = conn.up()
         cur.execute(sql)
         row = cur.fetchone()
-        cur.close()
+        conn.commit()
+        return row
+    except Exception as error:
+        return error
+    finally:
+        conn.down()
+
+def update_comment(incident_id, comment=None):
+    """
+    Update an incident's comment.
+    """
+    sql = f"""
+        UPDATE incidents
+        SET comment='{comment}'
+        WHERE incident_id = {incident_id}
+        RETURNING incident_id
+    """    
+    try:
+        conn = Connect()
+        cur = conn.up()
+        cur.execute(sql)
+        row = cur.fetchone()
+        conn.commit()
         return row
     except Exception as error:
         return error

--- a/api/models/database/incidentdb_api.py
+++ b/api/models/database/incidentdb_api.py
@@ -108,6 +108,28 @@ def get_all_intervention_incidents():
     finally:
         conn.down()
 
+def update_location(incident_id, location=None):
+    """
+    Update an incident's location.
+    """
+    sql = f"""
+        UPDATE incidents
+        SET location='{location}'
+        WHERE incident_id = {incident_id}
+        RETURNING incident_id
+    """    
+    try:
+        conn = Connect()
+        cur = conn.up()
+        cur.execute(sql)
+        row = cur.fetchone()
+        cur.close()
+        return row
+    except Exception as error:
+        return error
+    finally:
+        conn.down()
+
 def delete_user_by_type_and_user_id(type, user_id):
     """
     Delete all users.

--- a/api/models/incident_model.py
+++ b/api/models/incident_model.py
@@ -45,10 +45,10 @@ class Incident:
                 self.location = location
             return updated_data
         elif comment:
-            updated_data = data.update(self.id, comment=comment)
-            if updated_data['updated']:
+            updated_data = incidentdb_api.update_comment(self.id, comment=comment)
+            if updated_data['incident_id']:
                 self.comment = comment
-            return updated_data['data']
+            return updated_data
 
     def delete_incident(self):
         deleted = data.do_delete(self.id)

--- a/api/models/incident_model.py
+++ b/api/models/incident_model.py
@@ -1,6 +1,7 @@
 import random
 from datetime import date
 import data
+from api.models.database import incidentdb_api
 
 
 class Incident:
@@ -39,10 +40,10 @@ class Incident:
     def update_fields(self, location=None, comment=None):
 
         if location:
-            updated_data = data.update(self.id, location=location)
-            if updated_data['updated']:
+            updated_data = incidentdb_api.update_location(self.id, location=location)
+            if updated_data.get('incident_id'):
                 self.location = location
-            return updated_data['data']
+            return updated_data
         elif comment:
             updated_data = data.update(self.id, comment=comment)
             if updated_data['updated']:

--- a/api/tests/test_red_flags_route.py
+++ b/api/tests/test_red_flags_route.py
@@ -92,35 +92,39 @@ class TestRedFlagsRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("field should be red-flag", response_data['error'])
 
-    # def test_edit_red_flag_location(self):
+    def test_edit_red_flag_location(self):
 
-    #     data = {
-    #         "id": 2,
-    #         "createdOn": "12-12-2018",
-    #         "createdby": 5000,
-    #         "type": "red-flag",
-    #         "location": "33.92300, 44.9084551",
-    #         "status": "draft",
-    #         "images": ["image_1.png", "image_2.jpg"],
-    #         "videos": ["vid_1.mp4"],
-    #         "comment": "Accidental post!",
-    #         "title": "Roads in poor condition"
-    #     }
-    #     red_flags.append(data)
-    #     input_data = input_data = {
-    #         "location": "11.12345, 12.12345"
-    #     }
+        data = {"id": 36}
+        input_data = input_data = {
+            "location": "00.0000, 00.0001"
+        }
 
-    #     red_flag_id = data['id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/location'.format(red_flag_id),
-    #         json=input_data)
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 200)
-    #     self.assertIn("Updated red-flag record's location",
-    #                   response_data['data'][0]['message'])
-    #     self.assertEqual("11.12345, 12.12345",
-    #                      response_data['data'][0]['content']['location'])
+        red_flag_id = data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/location'.format(red_flag_id),
+            json=input_data)
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Updated red-flag record's location",
+                      response_data['data'][0]['message'])
+        self.assertEqual("00.0000, 00.0001",
+                         response_data['data'][0]['content']['location'])
+    
+    def test_edit_red_flag_location_with_invalid_location(self):
+
+        data = {"id": 36}
+        input_data = input_data = {
+            "location": "11.12345"
+        }
+
+        red_flag_id = data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/location'.format(red_flag_id),
+            json=input_data)
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Failed to update red-flag record's location",
+                      response_data['error'])
 
     # def test_edit_red_flag_comment(self):
 
@@ -192,33 +196,6 @@ class TestRedFlagsRoute(unittest.TestCase):
     #     self.assertEqual("""Invalid request - request body cannot be empty""",
     #                      response_data['error'])
 
-    # def test_edit_red_flag_location_with_invalid_location(self):
-
-    #     data = {
-    #         "id": 2,
-    #         "createdOn": "12-12-2018",
-    #         "createdby": 5000,
-    #         "type": "red-flag",
-    #         "location": "33.92300, 44.9084551",
-    #         "status": "draft",
-    #         "images": ["image_1.png", "image_2.jpg"],
-    #         "videos": ["vid_1.mp4"],
-    #         "comment": "Accidental post!",
-    #         "title": "Roads in poor condition"
-    #     }
-    #     red_flags.append(data)
-    #     input_data = input_data = {
-    #         "location": "11.12345"
-    #     }
-
-    #     red_flag_id = data['id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/location'.format(red_flag_id),
-    #         json=input_data)
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 400)
-    #     self.assertIn("Failed to update red-flag record's location",
-    #                   response_data['error'])
 
     # def test_edit_red_flag_comment_with_empty_string(self):
 

--- a/api/tests/test_red_flags_route.py
+++ b/api/tests/test_red_flags_route.py
@@ -20,6 +20,8 @@ class TestRedFlagsRoute(unittest.TestCase):
             "comment": "Accidental post!",
             "title": "Roads in poor condition"
          }
+        self.data = {"id": 36}
+
     def tearDown(self):
         incidentdb_api.delete_user_by_type_and_user_id(
             self.input_data['type'], self.input_data['createdby'])
@@ -33,10 +35,8 @@ class TestRedFlagsRoute(unittest.TestCase):
         self.assertEqual(200, response_data['status'])
 
     def test_get_red_flag_by_id(self):
-
-        data = {"id": 34}
         
-        red_flag_id = data['id']
+        red_flag_id = self.data['id']
         response = self.app_tester.get(
             '/api/v1/red-flags/{0}'.format(red_flag_id))
         response_data = json.loads(response.data.decode())
@@ -45,6 +45,7 @@ class TestRedFlagsRoute(unittest.TestCase):
         self.assertEqual(red_flag_id, response_data['data'][0]['id'])
 
     def test_get_red_flag_by_id_with_data_absent(self):
+
         input_data = {"red_flag_id": 12}
         red_flag_id = input_data['red_flag_id']
         response = self.app_tester.get(
@@ -57,10 +58,8 @@ class TestRedFlagsRoute(unittest.TestCase):
 
     def test_create_red_flag_with_data(self):
 
-
         response = self.app_tester.post('/api/v1/red-flags', json=self.input_data)
         response_data = json.loads(response.data.decode())
-        print(f"RESPONSE: {response_data}")
         self.assertEqual(response.status_code, 201)
         self.assertIn("Created red-flag record",
                       response_data['data'][0]['message'])
@@ -94,12 +93,11 @@ class TestRedFlagsRoute(unittest.TestCase):
 
     def test_edit_red_flag_location(self):
 
-        data = {"id": 36}
         input_data = input_data = {
             "location": "00.0000, 00.0001"
         }
 
-        red_flag_id = data['id']
+        red_flag_id = self.data['id']
         response = self.app_tester.patch(
             '/api/v1/red-flags/{0}/location'.format(red_flag_id),
             json=input_data)
@@ -112,12 +110,11 @@ class TestRedFlagsRoute(unittest.TestCase):
     
     def test_edit_red_flag_location_with_invalid_location(self):
 
-        data = {"id": 36}
         input_data = input_data = {
             "location": "11.12345"
         }
 
-        red_flag_id = data['id']
+        red_flag_id = self.data['id']
         response = self.app_tester.patch(
             '/api/v1/red-flags/{0}/location'.format(red_flag_id),
             json=input_data)
@@ -126,104 +123,63 @@ class TestRedFlagsRoute(unittest.TestCase):
         self.assertIn("Failed to update red-flag record's location",
                       response_data['error'])
 
-    # def test_edit_red_flag_comment(self):
+    def test_edit_red_flag_comment(self):
 
-    #     data = {
-    #         "id": 2,
-    #         "createdOn": "12-12-2018",
-    #         "createdby": 5000,
-    #         "type": "red-flag",
-    #         "location": "33.92300, 44.9084551",
-    #         "status": "draft",
-    #         "images": ["image_1.png", "image_2.jpg"],
-    #         "videos": ["vid_1.mp4"],
-    #         "comment": "Accidental post!",
-    #         "title": "Roads in poor condition"
-    #     }
-    #     red_flags.append(data)
-    #     input_data = input_data = {
-    #         "comment": "Comment updated"
-    #     }
+        input_data = input_data = {
+            "comment": "Comment updated"
+        }
 
-    #     red_flag_id = data['id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
-    #         json=input_data)
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 200)
-    #     self.assertIn("Updated red-flag record's comment",
-    #                   response_data['data'][0]['message'])
-    #     self.assertEqual("Comment updated",
-    #                      response_data['data'][0]['content']['comment'])
+        red_flag_id = self.data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
+            json=input_data)
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Updated red-flag record's comment",
+                      response_data['data'][0]['message'])
+        self.assertEqual("Comment updated",
+                         response_data['data'][0]['content']['comment'])
 
-    # def test_edit_red_flag_unknown_field_in_request_body(self):
+    def test_edit_red_flag_unknown_field_in_request_body(self):
 
-    #     data = {
-    #         "id": 2,
-    #         "createdOn": "12-12-2018",
-    #         "createdby": 5000,
-    #         "type": "red-flag",
-    #         "location": "33.92300, 44.9084551",
-    #         "status": "draft",
-    #         "images": ["image_1.png", "image_2.jpg"],
-    #         "videos": ["vid_1.mp4"],
-    #         "comment": "Accidental post!",
-    #         "title": "Roads in poor condition"
-    #     }
-    #     red_flags.append(data)
-    #     input_data = input_data = {
-    #         "coment": "Updated comment"
-    #     }
+        input_data = input_data = {
+            "coment": "Updated comment"
+        }
 
-    #     red_flag_id = data['id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
-    #         json=input_data)
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 404)
-    #     self.assertIn("Invalid field in request body", response_data['error'])
+        red_flag_id = self.data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
+            json=input_data)
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Invalid field in request body", response_data['error'])
 
-    # def test_edit_red_flag_with_data_absent(self):
+    def test_edit_red_flag_with_data_absent(self):
 
-    #     red_flags.clear()
-    #     data = {"red_flag_id": 12}
-    #     red_flag_id = data['red_flag_id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/comment'.format(red_flag_id))
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 400)
-    #     self.assertEqual(400, response_data['status'])
-    #     self.assertEqual("""Invalid request - request body cannot be empty""",
-    #                      response_data['error'])
+        red_flag_id = self.data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/comment'.format(red_flag_id))
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(400, response_data['status'])
+        self.assertEqual("""Invalid request - request body cannot be empty""",
+                         response_data['error'])
 
 
-    # def test_edit_red_flag_comment_with_empty_string(self):
+    def test_edit_red_flag_comment_with_empty_string(self):
 
-    #     data = {
-    #         "id": 2,
-    #         "createdOn": "12-12-2018",
-    #         "createdby": 5000,
-    #         "type": "red-flag",
-    #         "location": "33.92300, 44.9084551",
-    #         "status": "draft",
-    #         "images": ["image_1.png", "image_2.jpg"],
-    #         "videos": ["vid_1.mp4"],
-    #         "comment": "Accidental post!",
-    #         "title": "Roads in poor condition"
-    #     }
-    #     red_flags.append(data)
-    #     input_data = input_data = {
-    #         "comment": " "
-    #     }
+        input_data = input_data = {
+            "comment": " "
+        }
 
-    #     red_flag_id = data['id']
-    #     response = self.app_tester.patch(
-    #         '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
-    #         json=input_data)
-    #     response_data = json.loads(response.data.decode())
-    #     self.assertEqual(response.status_code, 400)
-    #     self.assertIn("Failed to update red-flag record's comment",
-    #                   response_data['error'])
+        red_flag_id = self.data['id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/comment'.format(red_flag_id),
+            json=input_data)
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Failed to update red-flag record's comment",
+                      response_data['error'])
 
     # def test_delete_red_flag(self):
 

--- a/api/views/red_flags_view.py
+++ b/api/views/red_flags_view.py
@@ -142,7 +142,7 @@ class RedFlagsView(MethodView):
                             "data": [{
                                 "id": red_flag_id,
                                 "message": "Updated red-flag record's comment",
-                                "content": updated_data
+                                "content": red_flag.to_dict()
                             }]
                         }
                 else:

--- a/api/views/red_flags_view.py
+++ b/api/views/red_flags_view.py
@@ -68,8 +68,6 @@ class RedFlagsView(MethodView):
                 raise ValueError("Empty request body")
             if validation_result["is_valid"]:
                 if request_data['type'].lower() == 'red-flag':
-                    #user_id = Authenticate.get_identity(request)
-                    #if user_id == request_data["createdBy"]:
                     red_flag = Incident(**request_data)
                     red_flag_id = incidentdb_api.create_incident(**red_flag.to_dict())
                     message = {"status": 201,
@@ -105,9 +103,12 @@ class RedFlagsView(MethodView):
 
             request_data = request.get_json()
             red_flag = None
-            for index, data in enumerate(incidents):
-                if incidents[index]['id'] == red_flag_id:
-                    red_flag = Incident(**data)
+            incident = incidentdb_api.get_incident_by_id(red_flag_id)
+            if incident and incident['incident_id'] == red_flag_id:
+                    red_flag = Incident(
+                        incident['incident_id'], 
+                        incident['createdon'], 
+                        **incident)                   
             if not red_flag:
                 error_message = {
                     "status": 404,
@@ -123,7 +124,7 @@ class RedFlagsView(MethodView):
                             "data": [{
                                 "id": red_flag_id,
                                 "message": "Updated red-flag record's location",
-                                "content": updated_data
+                                "content": red_flag.to_dict()
                             }]
                         }
                 else:


### PR DESCRIPTION
### What does this PR do?
 Integrate route to edit a comment on a red flag to the incidentdb_api
### Description of Task to be completed?

- [x] Remove all references to retrieving data from the data structure
- [x] Integrate route to incidentsdb_api to edit the comment
- [x] Refractor unit-tests tests for this route

## How should this be manually tested?
- Run the application and make the following request from Postman.
```
http://localhost:5000/api/v1/red-flags/<red_flag_id>/comment
 ```
- This will edit the comment return the updated red-flag from the database.
## What are the relevant pivotal tracker stories?
#163441036

## Reviewers
Kindly review this PR and provide feedback. 
@HabibSentongo
@Matsula77
@Rhytah
@NicholusMuwonge
@wasswa-derick