### PR TITLE
Edit status of an incident

### DIFF
--- a/api/models/database/incidentdb_api.py
+++ b/api/models/database/incidentdb_api.py
@@ -173,11 +173,11 @@ def update_comment(incident_id, comment=None):
 
 def update_status(incident_id, status=None):
     """
-    Update an incident's location.
+    Update an incident's status.
     """
     sql = f"""
         UPDATE incidents
-        SET location='{status}'
+        SET status='{status}'
         WHERE incident_id = {incident_id}
         RETURNING incident_id
     """    

--- a/api/models/database/incidentdb_api.py
+++ b/api/models/database/incidentdb_api.py
@@ -171,6 +171,28 @@ def update_comment(incident_id, comment=None):
     finally:
         conn.down()
 
+def update_status(incident_id, status=None):
+    """
+    Update an incident's location.
+    """
+    sql = f"""
+        UPDATE incidents
+        SET location='{status}'
+        WHERE incident_id = {incident_id}
+        RETURNING incident_id
+    """    
+    try:
+        conn = Connect()
+        cur = conn.up()
+        cur.execute(sql)
+        row = cur.fetchone()
+        conn.commit()
+        return row
+    except Exception as error:
+        return error
+    finally:
+        conn.down()
+
 def delete_user_by_type_and_user_id(type, user_id):
     """
     Delete a user by incident type and user ID.

--- a/api/models/incident_model.py
+++ b/api/models/incident_model.py
@@ -117,7 +117,7 @@ class Incident:
 
     @staticmethod
     def update_location(data, incident, type):
-        if Validate.is_valid_location(data['location']):
+        if Validate.is_valid_location(data['location']) and incident.type == type:
             updated_data = incident.update_fields(
                 location=data['location'])
             if updated_data:
@@ -136,7 +136,7 @@ class Incident:
     
     @staticmethod
     def update_comment(data, incident, type):
-        if not Validate.is_empty_string(data['comment']):
+        if not Validate.is_empty_string(data['comment']) and incident.type == type:
             updated_data = incident.update_fields(
                 comment=data['comment'])
             if updated_data:
@@ -158,7 +158,7 @@ class Incident:
         message = {
             'status': 400, 
             'error': f"Invalid Operation: Cannot update status {data['status']}"}
-        if Validate.is_valid_status(data['status']):
+        if Validate.is_valid_status(data['status']) and incident.type == type:
             updated_data = incident.update_fields(
                 status=data['status'])
             if updated_data:

--- a/api/models/incident_model.py
+++ b/api/models/incident_model.py
@@ -53,7 +53,7 @@ class Incident:
         return updated_data
 
     def delete_incident(self):
-        if g.user_id == self.createdBy or g.isAdmin == True:
+        if g.user_id == self.createdBy and self.status == 'draft':
             deleted = incidentdb_api.delete_incident_by_id(self.id)
             if deleted:
                 message = {

--- a/api/models/incident_model.py
+++ b/api/models/incident_model.py
@@ -38,11 +38,11 @@ class Incident:
     def update_fields(self, location=None, comment=None, status=None):
 
         updated_data = None
-        if location:
+        if location and self.status == 'draft':
             updated_data = incidentdb_api.update_location(self.id, location=location)
             if updated_data.get('incident_id'):
                 self.location = location
-        elif comment:
+        elif comment and self.status == 'draft':
             updated_data = incidentdb_api.update_comment(self.id, comment=comment)
             if updated_data['incident_id']:
                 self.comment = comment
@@ -117,6 +117,9 @@ class Incident:
 
     @staticmethod
     def update_location(data, incident, type):
+        message = {
+            'status': 400, 
+            'error': f"Invalid Operation: Cannot update status {incident.status}"}
         if Validate.is_valid_location(data['location']) and incident.type == type:
             updated_data = incident.update_fields(
                 location=data['location'])
@@ -136,6 +139,9 @@ class Incident:
     
     @staticmethod
     def update_comment(data, incident, type):
+        message = {
+            'status': 400, 
+            'error': f"Invalid Operation: Cannot update status {incident.status}"}
         if not Validate.is_empty_string(data['comment']) and incident.type == type:
             updated_data = incident.update_fields(
                 comment=data['comment'])

--- a/api/routes/urls.py
+++ b/api/routes/urls.py
@@ -4,7 +4,7 @@ from api.views.red_flags_view import RedFlagsView
 from api.views.users_view import UsersView
 from api.views.interventions_view import InterventionsView
 from api.views.user_incidents import UserRedFlagsView, UserInterventionsView
-from api.views.update_incidents import UpdateRedFlagsStatusView
+from api.views.update_incidents import UpdateRedFlagStatusView, UpdateInterventionStatusView
 
 
 class Routes:
@@ -18,7 +18,8 @@ class Routes:
         interventions_view = InterventionsView.as_view('intervention')
         user_red_flags_view = UserRedFlagsView.as_view('user_redflags')
         user_interventions_view = UserInterventionsView.as_view('user_interventions')
-        update_red_flags_status_view = UpdateRedFlagsStatusView.as_view('update_redflag_status')
+        update_red_flag_status_view = UpdateRedFlagStatusView.as_view('update_redflag_status')
+        update_intervention_status_view = UpdateInterventionStatusView.as_view('update_intervention_status')
 
         app.add_url_rule(
             '/api/v1/red-flags',
@@ -43,7 +44,7 @@ class Routes:
             methods=['PATCH'])
         app.add_url_rule(
             '/api/v1/red-flags/<int:incident_id>/status',
-            view_func=update_red_flags_status_view, 
+            view_func=update_red_flag_status_view, 
             methods=['PATCH'])
         app.add_url_rule(
             '/api/v1/red-flags/<int:red_flag_id>',
@@ -90,6 +91,10 @@ class Routes:
             '/api/v1/interventions/<int:intervention_id>/comment',
             view_func=interventions_view, 
             methods=['PATCH']),
+        app.add_url_rule(
+            '/api/v1/interventions/<int:incident_id>/status',
+            view_func=update_intervention_status_view, 
+            methods=['PATCH'])
         app.add_url_rule(
             '/api/v1/interventions/<int:intervention_id>',
             view_func=interventions_view, 

--- a/api/routes/urls.py
+++ b/api/routes/urls.py
@@ -4,6 +4,7 @@ from api.views.red_flags_view import RedFlagsView
 from api.views.users_view import UsersView
 from api.views.interventions_view import InterventionsView
 from api.views.user_incidents import UserRedFlagsView, UserInterventionsView
+from api.views.update_incidents import UpdateRedFlagsStatusView
 
 
 class Routes:
@@ -17,6 +18,7 @@ class Routes:
         interventions_view = InterventionsView.as_view('intervention')
         user_red_flags_view = UserRedFlagsView.as_view('user_redflags')
         user_interventions_view = UserInterventionsView.as_view('user_interventions')
+        update_red_flags_status_view = UpdateRedFlagsStatusView.as_view('update_redflag_status')
 
         app.add_url_rule(
             '/api/v1/red-flags',
@@ -38,6 +40,10 @@ class Routes:
         app.add_url_rule(
             '/api/v1/red-flags/<int:red_flag_id>/comment',
             view_func=red_flags_view, 
+            methods=['PATCH'])
+        app.add_url_rule(
+            '/api/v1/red-flags/<int:incident_id>/status',
+            view_func=update_red_flags_status_view, 
             methods=['PATCH'])
         app.add_url_rule(
             '/api/v1/red-flags/<int:red_flag_id>',

--- a/api/routes/urls.py
+++ b/api/routes/urls.py
@@ -4,8 +4,8 @@ from api.views.red_flags_view import RedFlagsView
 from api.views.users_view import UsersView
 from api.views.interventions_view import InterventionsView
 from api.views.user_incidents import UserRedFlagsView, UserInterventionsView
-from api.views.update_incidents import UpdateRedFlagStatusView, UpdateInterventionStatusView
-
+from api.views.update_incidents import UpdateRedFlagStatusView, UpdateInterventionStatusView, UpdateInterventionCommentView
+from api.views.update_incidents import UpdateRedFlagCommentView, UpdateInterventionLocationView, UpdateRedFlagLocationView
 
 class Routes:
 
@@ -20,6 +20,10 @@ class Routes:
         user_interventions_view = UserInterventionsView.as_view('user_interventions')
         update_red_flag_status_view = UpdateRedFlagStatusView.as_view('update_redflag_status')
         update_intervention_status_view = UpdateInterventionStatusView.as_view('update_intervention_status')
+        update_intervention_comment_view = UpdateInterventionCommentView.as_view('update_intervention_comment')
+        update_redflag_comment_view = UpdateRedFlagCommentView.as_view('update_redflag_comment')
+        update_intervention_location_view = UpdateInterventionLocationView.as_view('update_intervention_location')
+        update_redflag_location_view = UpdateRedFlagLocationView.as_view('update_redflag_location')
 
         app.add_url_rule(
             '/api/v1/red-flags',
@@ -35,12 +39,12 @@ class Routes:
             view_func=red_flags_view, 
             methods=['POST'])
         app.add_url_rule(
-            '/api/v1/red-flags/<int:red_flag_id>/location',
-            view_func=red_flags_view, 
+            '/api/v1/red-flags/<int:incident_id>/location',
+            view_func=update_redflag_location_view, 
             methods=['PATCH'])
         app.add_url_rule(
-            '/api/v1/red-flags/<int:red_flag_id>/comment',
-            view_func=red_flags_view, 
+            '/api/v1/red-flags/<int:incident_id>/comment',
+            view_func=update_redflag_comment_view, 
             methods=['PATCH'])
         app.add_url_rule(
             '/api/v1/red-flags/<int:incident_id>/status',
@@ -84,12 +88,12 @@ class Routes:
             view_func=interventions_view, 
             methods=['POST'])
         app.add_url_rule(
-            '/api/v1/interventions/<int:intervention_id>/location',
-            view_func=interventions_view, 
+            '/api/v1/interventions/<int:incident_id>/location',
+            view_func=update_intervention_location_view, 
             methods=['PATCH'])
         app.add_url_rule(
-            '/api/v1/interventions/<int:intervention_id>/comment',
-            view_func=interventions_view, 
+            '/api/v1/interventions/<int:incident_id>/comment',
+            view_func=update_intervention_comment_view, 
             methods=['PATCH']),
         app.add_url_rule(
             '/api/v1/interventions/<int:incident_id>/status',

--- a/api/tests/test_interventions_route.py
+++ b/api/tests/test_interventions_route.py
@@ -294,8 +294,8 @@ class TestInterventions(unittest.TestCase):
             headers=dict(
                 Authorization = 'Bearer ' + f"{token}"))
         response_data = json.loads(response.data.decode())
-        self.assertEqual(response.status_code, 404)
-        self.assertIn("Invalid field in request body", response_data['error'])
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("Unauthorized", response_data['error'])
 
     def test_edit_intervention_with_data_absent(self):
 

--- a/api/tests/test_red_flags_route.py
+++ b/api/tests/test_red_flags_route.py
@@ -297,8 +297,8 @@ class TestRedFlagsRoute(unittest.TestCase):
             headers=dict(
                 Authorization = 'Bearer ' + f"{token}"))
         response_data = json.loads(response.data.decode())
-        self.assertEqual(response.status_code, 404)
-        self.assertIn("Invalid field in request body", response_data['error'])
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("Unauthorized", response_data['error'])
 
     def test_edit_red_flag_with_data_absent(self):
 
@@ -432,7 +432,7 @@ class TestRedFlagsRoute(unittest.TestCase):
         response_data = json.loads(response.data.decode())
         self.assertEqual(response.status_code, 404)  
 
-    def test_edit_red_flag_status(self):
+    def test_update_red_flag_status(self):
 
         response = self.app_tester.post(
             '/api/v1/auth/login',
@@ -467,5 +467,5 @@ class TestRedFlagsRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Updated red-flag record's status",
                       response_data['data'][0]['message'])
-        self.assertEqual("Status updated",
+        self.assertEqual("under-investigation",
                          response_data['data'][0]['content']['status'])

--- a/api/tests/test_red_flags_route.py
+++ b/api/tests/test_red_flags_route.py
@@ -24,7 +24,18 @@ class TestRedFlagsRoute(unittest.TestCase):
             "password": """sha256$M0lFuN76$f4f847832c559f5a38c317d334aeb110184dad95063dd28559bb40a4b69be0d6""",
             "isAdmin" : False
         }
+        self.user_data_admin = {
+            "firstname": "Jane",
+            "lastname": "Jones",
+            "othernames": "",
+            "email": "adminJane@email.com",
+            "phonenumber": "0775778887",
+            "username": "adminJane",
+            "password": """sha256$M0lFuN76$f4f847832c559f5a38c317d334aeb110184dad95063dd28559bb40a4b69be0d6""",
+            "isAdmin" : True
+        }
         self.user_id = userdb_api.create_user(**self.user_data)
+        self.admin_id = userdb_api.create_user(**self.user_data_admin)
         self.input_data = {
             "createdby": self.user_id['user_id'],
             "type": "red-flag",
@@ -42,6 +53,8 @@ class TestRedFlagsRoute(unittest.TestCase):
             self.input_data['createdby'])
         userdb_api.delete_user_by_email(
             self.user_data['email'])
+        userdb_api.delete_user_by_email(
+            self.user_data_admin['email'])
 
 
     def test_get_red_flags_with_data_present(self):
@@ -418,3 +431,41 @@ class TestRedFlagsRoute(unittest.TestCase):
         )
         response_data = json.loads(response.data.decode())
         self.assertEqual(response.status_code, 404)  
+
+    def test_edit_red_flag_status(self):
+
+        response = self.app_tester.post(
+            '/api/v1/auth/login',
+            json={
+            "username": "jane",
+            "password": "entersaysme"
+            })
+        response_data = json.loads(response.data.decode())
+        self.input_data['createdby'] = response_data['data'][0]['user']['id']
+        data = incidentdb_api.create_incident(**self.input_data)
+
+        response = self.app_tester.post(
+            '/api/v1/auth/login',
+            json={
+            "username": "adminJane",
+            "password": "entersaysme"
+            })
+        response_data = json.loads(response.data.decode())
+        token = response_data['data'][0]['access_token']
+
+        input_data = input_data = {
+            "status": "under-investigation"
+        }
+
+        red_flag_id = data['incident_id']
+        response = self.app_tester.patch(
+            '/api/v1/red-flags/{0}/status'.format(red_flag_id),
+            json=input_data,
+            headers=dict(
+                Authorization = 'Bearer ' + f"{token}"))
+        response_data = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Updated red-flag record's status",
+                      response_data['data'][0]['message'])
+        self.assertEqual("Status updated",
+                         response_data['data'][0]['content']['status'])

--- a/api/validator.py
+++ b/api/validator.py
@@ -120,6 +120,19 @@ class Validate:
         else:
             is_valid = False
         return is_valid
+    
+    @staticmethod
+    def is_valid_status(status):
+        expected = [
+            'under-investigation',
+            'resolved',
+            'rejected'
+        ]
+        if status in expected:
+            is_valid = True
+        else:
+            is_valid = False
+        return is_valid
 
     @staticmethod
     def validate_token(token):

--- a/api/views/interventions_view.py
+++ b/api/views/interventions_view.py
@@ -75,32 +75,6 @@ class InterventionsView(MethodView):
                 error_message.update({"error-type": str(error)})
         return jsonify(error_message), error_message['status'] 
 
-    def patch(self, intervention_id):
-
-        token = Authenticate.retrieve_token_from_request(request)
-        error_message = {'status': 400}
-        try:
-            validation_result = Validate.validate_request_body(request)
-            if validation_result["is_valid"]:
-                request_data = request.get_json()
-                intervention = Incident.get_incident(intervention_id)
-                is_valid_token = Validate.validate_token(token)
-                if  is_valid_token['is_valid'] and not intervention['error']:
-                    message = Incident.update_incident(request_data, intervention['incident'], 'intervention')
-                    return jsonify(message), message['status']
-                else:
-                    error_message = {
-                    'status': is_valid_token['status'] or intervention['error']['status'],
-                    'error': is_valid_token['error'] or intervention['error']['error']}
-                    raise Exception
-            else:
-                error_message = validation_result['message']
-                raise Exception("Validation Error")
-        except ValueError as error:
-            error_message.update({"error-type": str(error)})
-        except Exception as error:
-            error_message.update({"error-type": str(error)})
-        return jsonify(error_message), error_message['status']
 
     def delete(self, intervention_id):
 

--- a/api/views/red_flags_view.py
+++ b/api/views/red_flags_view.py
@@ -76,33 +76,6 @@ class RedFlagsView(MethodView):
             error_message.update({"error-type": str(error)})
         return jsonify(error_message), error_message['status']
 
-    def patch(self, red_flag_id):
-
-        token = Authenticate.retrieve_token_from_request(request)
-        error_message = {'status': 400}
-        try:
-            validation_result = Validate.validate_request_body(request)
-            if validation_result["is_valid"]:
-                request_data = request.get_json()
-                red_flag = Incident.get_incident(red_flag_id)
-                is_valid_token = Validate.validate_token(token)
-                if  is_valid_token['is_valid'] and not red_flag['error']:
-                    message = Incident.update_incident(request_data, red_flag['incident'], 'red-flag')
-                    return jsonify(message), message['status']
-                else:
-                    error_message = {
-                    'status': is_valid_token['status'] or red_flag['error']['status'],
-                    'error': is_valid_token['error'] or red_flag['error']['error']}
-                    raise Exception
-            else:
-                error_message = validation_result['message']
-                raise Exception("Validation Error")
-        except ValueError as error:
-            error_message.update({"error-type": str(error)})
-        except Exception as error:
-            error_message.update({"error-type": str(error)})
-        return jsonify(error_message), error_message['status']
-
     def delete(self, red_flag_id):
 
         token = Authenticate.retrieve_token_from_request(request)

--- a/api/views/update_incidents.py
+++ b/api/views/update_incidents.py
@@ -41,19 +41,19 @@ class BaseView(MethodView):
         return jsonify(error_message), error_message['status']
 
 
-class UpdateRedFlagsLocationView(BaseView):
+class UpdateRedFlagLocationView(BaseView):
     def __init__(self):
         super().__init__('red-flag')
             
-class UpdateInterventionsLocationView(BaseView):
+class UpdateInterventionLocationView(BaseView):
     def __init__(self):
         super().__init__('intervention')
 
-class UpdateRedFlagsCommentView(BaseView):
+class UpdateRedFlagCommentView(BaseView):
     def __init__(self):
         super().__init__('red-flag')            
 
-class UpdateInterventionsCommentView(BaseView):
+class UpdateInterventionCommentView(BaseView):
     def __init__(self):
         super().__init__('intervention')
 

--- a/api/views/update_incidents.py
+++ b/api/views/update_incidents.py
@@ -58,11 +58,11 @@ class UpdateInterventionsCommentView(BaseView):
     def __init__(self):
         super().__init__('intervention')
 
-class UpdateRedFlagsStatusView(BaseView):
+class UpdateRedFlagStatusView(BaseView):
     def __init__(self):
         super().__init__('red-flag')
             
-class UpdateInterventionsStatusView(BaseView):
+class UpdateInterventionStatusView(BaseView):
     def __init__(self):
         super().__init__('intervention')
 

--- a/api/views/update_incidents.py
+++ b/api/views/update_incidents.py
@@ -1,0 +1,68 @@
+from flask import jsonify, request, g
+from flask.views import MethodView
+from flask_jwt import jwt
+
+from api.auth.authenticate import Authenticate
+from api.models.database import incidentdb_api
+from api.models.incident_model import Incident
+from api.validator import Validate
+
+
+class BaseView(MethodView):
+
+    def __init__(self, type):
+        self.type = type;
+
+    def patch(self, incident_id):
+
+        token = Authenticate.retrieve_token_from_request(request)
+        error_message = {'status': 400}
+        try:
+            validation_result = Validate.validate_request_body(request)
+            if validation_result["is_valid"]:
+                request_data = request.get_json()
+                incident = Incident.get_incident(incident_id)
+                is_valid_token = Validate.validate_token(token)
+                if  is_valid_token['is_valid'] and not incident['error']:
+                    message = Incident.update_incident(request_data, incident['incident'], self.type)
+                    return jsonify(message), message['status']
+                else:
+                    error_message = {
+                    'status': is_valid_token['status'] or incident['error']['status'],
+                    'error': is_valid_token['error'] or incident['error']['error']}
+                    raise Exception
+            else:
+                error_message = validation_result['message']
+                raise Exception("Validation Error")
+        except ValueError as error:
+            error_message.update({"error-type": str(error)})
+        except Exception as error:
+            error_message.update({"error-type": str(error)})
+        return jsonify(error_message), error_message['status']
+
+
+class UpdateRedFlagsLocationView(BaseView):
+    def __init__(self):
+        super().__init__('red-flag')
+            
+
+class UpdateInterventionsLocationView(BaseView):
+    def __init__(self):
+        super().__init__('intervention')
+
+class UpdateRedFlagsCommentView(BaseView):
+    def __init__(self):
+        super().__init__('red-flag')            
+
+class UpdateInterventionsCommentView(BaseView):
+    def __init__(self):
+        super().__init__('intervention')
+
+class UpdateRedFlagsStatusView(BaseView):
+    def __init__(self):
+        super().__init__('red-flag')
+            
+class UpdateInterventionsStatusView(BaseView):
+    def __init__(self):
+        super().__init__('intervention')
+

--- a/api/views/update_incidents.py
+++ b/api/views/update_incidents.py
@@ -45,7 +45,6 @@ class UpdateRedFlagsLocationView(BaseView):
     def __init__(self):
         super().__init__('red-flag')
             
-
 class UpdateInterventionsLocationView(BaseView):
     def __init__(self):
         super().__init__('intervention')


### PR DESCRIPTION
### What does this PR do?
 Add API endpoint to edit an incident's status 
### Description of Task to be completed?

- [x] Create a method in the incidentdb_api to update the status of an incident
- [x] Create endpoint that can be consumed to update the status
- [x] Restrict updating of status to Admin users only
- [x] Restrict updating to incidents with a status of 'draft'
## How should this be manually tested?
- Login to the application as an admin and store the token
- Pass the token the request to the link below with the updated status
as the body
```
http://localhost:5000/api/v1/red-flags/<red_flag_id>/status
 ```
- This will update the incident if and only if the current status of the incident
is 'draft'.
## What are the relevant pivotal tracker stories?
#163704895